### PR TITLE
failing unit test

### DIFF
--- a/mergo_test.go
+++ b/mergo_test.go
@@ -95,6 +95,67 @@ func TestPointerStruct(t *testing.T) {
 	}
 }
 
+type embeddingStruct struct {
+	embeddedStruct
+}
+
+type embeddedStruct struct {
+	A string
+}
+
+func TestEmbeddedStruct(t *testing.T) {
+	tests := []struct {
+		src      embeddingStruct
+		dst      embeddingStruct
+		expected embeddingStruct
+	}{
+		{
+			src: embeddingStruct{
+				embeddedStruct{"foo"},
+			},
+			dst: embeddingStruct{
+				embeddedStruct{""},
+			},
+			expected: embeddingStruct{
+				embeddedStruct{"foo"},
+			},
+		},
+		{
+			src: embeddingStruct{
+				embeddedStruct{""},
+			},
+			dst: embeddingStruct{
+				embeddedStruct{"bar"},
+			},
+			expected: embeddingStruct{
+				embeddedStruct{"bar"},
+			},
+		},
+		{
+			src: embeddingStruct{
+				embeddedStruct{"foo"},
+			},
+			dst: embeddingStruct{
+				embeddedStruct{"bar"},
+			},
+			expected: embeddingStruct{
+				embeddedStruct{"bar"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		err := Merge(&test.dst, test.src)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
+		if !reflect.DeepEqual(test.dst, test.expected) {
+			t.Errorf("unexpected output\nexpected:\n%+v\nsaw:\n%+v\n", test.expected, test.dst)
+		}
+	}
+}
+
 func TestPointerStructNil(t *testing.T) {
 	a := pointerTest{nil}
 	b := pointerTest{&simpleTest{19}}


### PR DESCRIPTION
Do not merge, failing test. I was trying to write some tests for embedded structs as there weren't any and I'm getting some unexpected behavior on the last test case:
```go
{
	src: embeddingStruct{
		embeddedStruct{"foo"},
	},
	dst: embeddingStruct{
		embeddedStruct{"bar"},
	},
	expected: embeddingStruct{
		embeddedStruct{"bar"},
	},
},
```
which is failing with this output:
```
=== RUN TestEmbeddedStruct
--- FAIL: TestEmbeddedStruct (0.00s)
	mergo_test.go:132: unexpected output
		expected:
		{embeddedStruct:{A:bar}}
		saw:
		{embeddedStruct:{A:foo}}
FAIL
exit status 1
FAIL	github.com/imdario/mergo	0.004s
```

I would expect dst to keep it's "bar" field as it's not the default value of string. Per the Merge documentation, Merge sets fields' values in dst from src if they have a zero value of their type. Is this unexpected behavior?