### PR TITLE
Merge occurs if src value is different than default

### DIFF
--- a/map.go
+++ b/map.go
@@ -57,7 +57,7 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, over
 			}
 			fieldName := field.Name
 			fieldName = changeInitialCase(fieldName, unicode.ToLower)
-			if v, ok := dstMap[fieldName]; !ok || (isEmptyValue(reflect.ValueOf(v)) || overwrite) {
+			if v, ok := dstMap[fieldName]; !ok || (isEmptyValue(reflect.ValueOf(v), nil) || overwrite) {
 				dstMap[fieldName] = src.Field(i).Interface()
 			}
 		}
@@ -89,7 +89,7 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, over
 				continue
 			}
 			if srcKind == dstKind {
-				if err = deepMerge(dstElement, srcElement, visited, depth+1, overwrite); err != nil {
+				if err = deepMerge(dstElement, srcElement, "", visited, depth+1, overwrite); err != nil {
 					return
 				}
 			} else {
@@ -136,7 +136,7 @@ func _map(dst, src interface{}, overwrite bool) error {
 	// To be friction-less, we redirect equal-type arguments
 	// to deepMerge. Only because arguments can be anything.
 	if vSrc.Kind() == vDst.Kind() {
-		return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0, overwrite)
+		return deepMerge(vDst, vSrc, "", make(map[uintptr]*visit), 0, overwrite)
 	}
 	switch vSrc.Kind() {
 	case reflect.Struct:

--- a/merge.go
+++ b/merge.go
@@ -15,7 +15,7 @@ import (
 // Traverses recursively both values, assigning src's fields values to dst.
 // The map argument tracks comparisons that have already been seen, which allows
 // short circuiting on recursive types.
-func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, overwrite bool) (err error) {
+func deepMerge(dst, src reflect.Value, tag reflect.StructTag, visited map[uintptr]*visit, depth int, overwrite bool) (err error) {
 	if !src.IsValid() {
 		return
 	}
@@ -35,7 +35,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, ov
 	switch dst.Kind() {
 	case reflect.Struct:
 		for i, n := 0, dst.NumField(); i < n; i++ {
-			if err = deepMerge(dst.Field(i), src.Field(i), visited, depth+1, overwrite); err != nil {
+			if err = deepMerge(dst.Field(i), src.Field(i), src.Type().Field(i).Tag, visited, depth+1, overwrite); err != nil {
 				return
 			}
 		}
@@ -57,12 +57,12 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, ov
 				case reflect.Struct:
 					fallthrough
 				case reflect.Map:
-					if err = deepMerge(dstElement, srcElement, visited, depth+1, overwrite); err != nil {
+					if err = deepMerge(dstElement, srcElement, tag, visited, depth+1, overwrite); err != nil {
 						return
 					}
 				}
 			}
-			if !isEmptyValue(srcElement) && (overwrite || (!dstElement.IsValid() || isEmptyValue(dst))) {
+			if !isEmptyValue(srcElement, nil) && (overwrite || (!dstElement.IsValid() || isEmptyValue(dst, nil))) {
 				if dst.IsNil() {
 					dst.Set(reflect.MakeMap(dst.Type()))
 				}
@@ -75,14 +75,14 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, ov
 		if src.IsNil() {
 			break
 		} else if dst.IsNil() {
-			if dst.CanSet() && (overwrite || isEmptyValue(dst)) {
+			if dst.CanSet() && (overwrite || isEmptyValue(dst, tag.Get(TagName))) {
 				dst.Set(src)
 			}
-		} else if err = deepMerge(dst.Elem(), src.Elem(), visited, depth+1, overwrite); err != nil {
+		} else if err = deepMerge(dst.Elem(), src.Elem(), tag, visited, depth+1, overwrite); err != nil {
 			return
 		}
 	default:
-		if dst.CanSet() && !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) {
+		if dst.CanSet() && !isEmptyValue(src, tag.Get(TagName)) && (overwrite || isEmptyValue(dst, tag.Get(TagName))) {
 			dst.Set(src)
 		}
 	}
@@ -114,5 +114,5 @@ func merge(dst, src interface{}, overwrite bool) error {
 	if vDst.Type() != vSrc.Type() {
 		return ErrDifferentArgumentsTypes
 	}
-	return deepMerge(vDst, vSrc, make(map[uintptr]*visit), 0, overwrite)
+	return deepMerge(vDst, vSrc, "", make(map[uintptr]*visit), 0, overwrite)
 }

--- a/mergo.go
+++ b/mergo.go
@@ -11,6 +11,11 @@ package mergo
 import (
 	"errors"
 	"reflect"
+	"strconv"
+)
+
+const (
+	TagName = "default_value"
 )
 
 // Errors reported by Mergo when it finds invalid arguments.
@@ -33,18 +38,45 @@ type visit struct {
 }
 
 // From src/pkg/encoding/json.
-func isEmptyValue(v reflect.Value) bool {
+func isEmptyValue(v reflect.Value, defaultValue interface{}) bool {
+	strDefaultValue := reflect.ValueOf(defaultValue).String()
 	switch v.Kind() {
-	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
-		return v.Len() == 0
+	case reflect.String:
+		if strDefaultValue == "" {
+			return v.Len() == 0
+		} else {
+			return v.String() == strDefaultValue
+		}
+	case reflect.Array, reflect.Map, reflect.Slice:
+		if value, err := strconv.ParseInt(strDefaultValue, 10, 32); err != nil || strDefaultValue == "" {
+			return v.Len() == 0
+		} else {
+			return int64(v.Len()) == value
+		}
 	case reflect.Bool:
-		return !v.Bool()
+		if value, err := strconv.ParseBool(strDefaultValue); err != nil || strDefaultValue == "" {
+			return !v.Bool()
+		} else {
+			return v.Bool() == value
+		}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return v.Int() == 0
+		if value, err := strconv.ParseInt(strDefaultValue, 10, 64); err != nil || strDefaultValue == "" {
+			return v.Int() == 0
+		} else {
+			return v.Int() == value
+		}
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return v.Uint() == 0
+		if value, err := strconv.ParseUint(strDefaultValue, 10, 64); err != nil || strDefaultValue == "" {
+			return v.Uint() == 0
+		} else {
+			return v.Uint() == value
+		}
 	case reflect.Float32, reflect.Float64:
-		return v.Float() == 0
+		if value, err := strconv.ParseFloat(strDefaultValue, 64); err != nil || strDefaultValue == "" {
+			return v.Float() == 0
+		} else {
+			return v.Float() == value
+		}
 	case reflect.Interface, reflect.Ptr:
 		return v.IsNil()
 	}

--- a/mergo_test.go
+++ b/mergo_test.go
@@ -439,3 +439,73 @@ func loadYAML(path string) (m map[string]interface{}) {
 	_ = yaml.Unmarshal(raw, &m)
 	return
 }
+
+type simpleTestTag struct {
+	Value int `default_value:"50"`
+}
+
+type complexTestTag struct {
+	St   simpleTestTag
+	sz   int    `default_value:"100"`
+	Id   string `default_value:"foo"`
+	Flag bool   `default_value:"true"`
+}
+
+type moreComplextTextTag struct {
+	Ct complexTestTag
+	St simpleTestTag
+	Nt simpleTestTag
+}
+
+type pointerTestTag struct {
+	C *simpleTestTag
+}
+
+type sliceTestTag struct {
+	S []int
+}
+
+func TestComplexStructTag(t *testing.T) {
+	a := complexTestTag{St: simpleTestTag{Value: 50}}
+	a.Id = "athing"
+	b := complexTestTag{simpleTestTag{42}, 1, "bthing", false}
+	if err := Merge(&a, b); err != nil {
+		t.FailNow()
+	}
+	if a.St.Value != 42 {
+		t.Fatalf("b not merged in properly: a.St.Value(%d) != b.St.Value(%d)", a.St.Value, b.St.Value)
+	}
+	if a.sz == 1 {
+		t.Fatalf("a's private field sz not preserved from merge: a.sz(%d) == b.sz(%d)", a.sz, b.sz)
+	}
+	if a.Id == b.Id {
+		t.Fatalf("a's field Id merged unexpectedly: a.Id(%s) == b.Id(%s)", a.Id, b.Id)
+	}
+}
+
+func TestComplexStructWithOverwriteTag(t *testing.T) {
+	a := complexTestTag{simpleTestTag{50}, 100, "foo", false}
+	b := complexTestTag{simpleTestTag{0}, 2, "", true}
+
+	expect := complexTestTag{simpleTestTag{0}, 100, "", false}
+	if err := MergeWithOverwrite(&a, b); err != nil {
+		t.FailNow()
+	}
+
+	if !reflect.DeepEqual(a, expect) {
+		t.Fatalf("Test failed:\ngot  :\n%#v\n\nwant :\n%#v\n\n", a, expect)
+	}
+}
+
+func TestPointerStructTag(t *testing.T) {
+	s1 := simpleTestTag{50}
+	s2 := simpleTestTag{19}
+	a := pointerTestTag{&s1}
+	b := pointerTestTag{&s2}
+	if err := Merge(&a, b); err != nil {
+		t.FailNow()
+	}
+	if a.C.Value != b.C.Value {
+		t.Fatalf("b not merged in properly: a.C.Value(%d) != b.C.Value(%d)", a.C.Value, b.C.Value)
+	}
+}


### PR DESCRIPTION
Instead of relying only on go's default empty values, I added a possibility to have the default empty values that the user wants by using the tag "default_value" in the fields of struct.

Signed-off-by: André Martins martins@noironetworks.com
