### PR TITLE
initialize destination map if nil

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -55,6 +55,9 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, ov
 				}
 			}
 			if !isEmptyValue(srcElement) && (overwrite || (!dstElement.IsValid() || isEmptyValue(dst))) {
+				if dst.IsNil() {
+					dst.Set(reflect.MakeMap(dst.Type()))
+				}
 				dst.SetMapIndex(key, srcElement)
 			}
 		}


### PR DESCRIPTION
fixes a `panic: assignment to entry in nil map` at: `merge.go:58` if the destination map is nil