### PR TITLE
Keep children keys when merge map with overwrite

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -62,7 +62,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, ov
 					}
 				}
 			}
-			if reflect.TypeOf(srcElement.Interface()).Kind() == reflect.Map {
+			if dstElement.IsValid() && reflect.TypeOf(srcElement.Interface()).Kind() == reflect.Map {
 				continue
 			}
 

--- a/merge.go
+++ b/merge.go
@@ -62,6 +62,10 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, ov
 					}
 				}
 			}
+			if reflect.TypeOf(srcElement.Interface()).Kind() == reflect.Map {
+				continue
+			}
+
 			if !isEmptyValue(srcElement) && (overwrite || (!dstElement.IsValid() || isEmptyValue(dst))) {
 				if dst.IsNil() {
 					dst.Set(reflect.MakeMap(dst.Type()))

--- a/mergo_test.go
+++ b/mergo_test.go
@@ -492,6 +492,45 @@ func TestTime(t *testing.T) {
 	}
 }
 
+func TestMapWithoutField(t *testing.T) {
+	m := map[string]map[string]string{
+		"parent1": {
+			"child1_1": "value1_1",
+			"child1_2": "value1_2",
+		},
+	}
+
+	n := map[string]map[string]string{
+		"parent1": {
+			"child1_1": "updated1_1",
+
+			"child1_3": "updated1_3",
+		},
+		"parent2": {
+			"child2_1": "updated2_1",
+		},
+	}
+
+	expect := map[string]map[string]string{
+		"parent1": {
+			"child1_1": "updated1_1",
+			"child1_2": "value1_2",
+			"child1_3": "updated1_3",
+		},
+		"parent2": {
+			"child2_1": "updated2_1",
+		},
+	}
+
+	if err := MergeWithOverwrite(&m, n); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if !reflect.DeepEqual(m, expect) {
+		t.Fatalf("Test failed:\ngot  :\n%#v\n\nwant :\n%#v\n\n", m, expect)
+	}
+}
+
 func loadYAML(path string) (m map[string]interface{}) {
 	m = make(map[string]interface{})
 	raw, _ := ioutil.ReadFile(path)

--- a/mergo_test.go
+++ b/mergo_test.go
@@ -312,12 +312,37 @@ func TestMaps(t *testing.T) {
 	}
 }
 
+func TestYAMLMapsWithOverwrite(t *testing.T) {
+	thing := loadYAML("testdata/thing.yml")
+	license := loadYAML("testdata/license.yml")
+	ft := thing["fields"].(map[interface{}]interface{})
+	fl := license["fields"].(map[interface{}]interface{})
+	expectedLength := len(ft) + len(fl) - 1
+	if err := MergeWithOverwrite(&license, thing); err != nil {
+		t.Fatal(err.Error())
+	}
+	currentLength := len(license["fields"].(map[interface{}]interface{}))
+	if currentLength != expectedLength {
+		t.Fatalf(`thing not merged in license properly, license must have %d elements instead of %d`, expectedLength, currentLength)
+	}
+	fields := license["fields"].(map[interface{}]interface{})
+	if _, ok := fields["site"]; !ok {
+		t.Fatalf(`thing not merged in license properly, license must keep a site field`)
+	}
+	if _, ok := fields["id"]; !ok {
+		t.Fatalf(`thing not merged in license properly, license must have a new id field from thing`)
+	}
+	if f, ok := fields["author"]; !ok || f != "updater" {
+		t.Fatalf(`thing not merged in license properly, license must have a author field with updated value from thing`)
+	}
+}
+
 func TestYAMLMaps(t *testing.T) {
 	thing := loadYAML("testdata/thing.yml")
 	license := loadYAML("testdata/license.yml")
 	ft := thing["fields"].(map[interface{}]interface{})
 	fl := license["fields"].(map[interface{}]interface{})
-	expectedLength := len(ft) + len(fl)
+	expectedLength := len(ft) + len(fl) - 1
 	if err := Merge(&license, thing); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -328,6 +353,9 @@ func TestYAMLMaps(t *testing.T) {
 	fields := license["fields"].(map[interface{}]interface{})
 	if _, ok := fields["id"]; !ok {
 		t.Fatalf(`thing not merged in license properly, license must have a new id field from thing`)
+	}
+	if f, ok := fields["author"]; !ok || f != "root" {
+		t.Fatalf(`thing not merged in license properly, license must keep a author field with original value`)
 	}
 }
 

--- a/testdata/license.yml
+++ b/testdata/license.yml
@@ -1,3 +1,4 @@
 import: ../../../../fossene/db/schema/thing.yml
 fields:
     site: string
+    author: root

--- a/testdata/thing.yml
+++ b/testdata/thing.yml
@@ -3,3 +3,4 @@ fields:
     name: string
     parent: ref "datu:thing"
     status: enum(draft, public, private)
+    author: updater


### PR DESCRIPTION
`MergeWithOverwrite` should keep children keys like `Merge`
## Problem

When merge two deep maps like below.

```
var map1 = map[string]map[string]string{
  "parent1": {
    "child1": "value1",
    "child2": "value2",
  },
  "parent2": {
    "child2_1": "value2_1",
  },
}

var map2 = map[string]map[string]string{
  "parent1": {
    "child1": "updated1",

    "child3": "updated3",
  },
}

mergo.MergeWithOverwrite(&map1, map2)
```
### mergo.Merge

```
map[string]map[string]string{
    "parent1": {"child1":"value1", "child2":"value2", "child3":"updated3"},
    "parent2": {"child2_1":"value2_1"},
}
```

Keep `parent1`, `parent2`, `child1`, `child2` and `child3` correctly.
### mergo.MergeWithOverwrite

```
map[string]map[string]string{
    "parent2": {"child2_1":"value2_1"},
    "parent1": {"child1":"updated1", "child3":"updated3"},
}
```

Keep `parent1`, `parent2`. But original child key `child2` is lost.
## Solution

Recursive `deepMerge` has already merged map completely.
I think that `dst.SetMapIndex` isn't necessary to merge map.
## Remarks

Ruby 2.1.5p2773 with ActiveSupport 4.2.5 will return following result that contains `child2`.

```
require 'active_support'
require 'active_support/core_ext'

map1 = {
  parent1: {
    child1: 'value1',
    child2: 'value2'
  },
  parent2: {
    child2_1: 'value2-1'
  }
}

map2 = {
  parent1: {
    child1: 'udpated1',

    child3: 'updated3'
  }
}

map1.deep_merge(map2)
# => {:parent1=>{:child1=>"udpated1", :child2=>"value2", :child3=>"updated3"}, :parent2=>{:child2_1=>"value2-1"}
```
