### PR TITLE
adding MergeWithOverwrite info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,27 @@ If you were using Mergo **before** April 6th 2015, please check your project wor
 
 You can only merge same-type structs with exported fields initialized as zero value of their type and same-types maps. Mergo won't merge unexported (private) fields but will do recursively any exported one. Also maps will be merged recursively except for structs inside maps (because they are not addressable using Go reflection).
 
-    if err := mergo.Merge(&dst, src); err != nil {
-        // ...
-    }
+```go
+if err := mergo.Merge(&dst, src); err != nil {
+    // ...
+}
+```
+
+Also, you can merge overwriting values using MergeWithOverwrite.
+
+```go
+if err := mergo.MergeWithOverwrite(&dst, src); err != nil {
+    // ...
+}
+```
 
 Additionally, you can map a map[string]interface{} to a struct (and otherwise, from struct to map), following the same restrictions as in Merge(). Keys are capitalized to find each corresponding exported field.
 
-    if err := mergo.Map(&dst, srcMap); err != nil {
-        // ...
-    }
+```go
+if err := mergo.Map(&dst, srcMap); err != nil {
+    // ...
+}
+```
 
 Warning: if you map a struct to map, it won't do it recursively. Don't expect Mergo to map struct members of your struct as map[string]interface{}. They will be just assigned as values.
 


### PR DESCRIPTION
This PR adds info of the method `MergeWithOverwrite` to the README. I was expecting that `Merge` actually act like `MergeWithOverwrite`, probably this is something we need to show in the README.

Also, makes some minor fixes to the code highlighting.