### PR TITLE
edge cases fixes

### DIFF
--- a/map.go
+++ b/map.go
@@ -91,22 +91,19 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, over
 				continue
 			}
 			if srcKind == dstKind {
-				if err = deepMerge(dstElement, srcElement, visited, depth+1, overwrite); err != nil {
+				if err = deepMerge(dstElement, srcElement, visited, depth + 1, overwrite); err != nil {
+					return
+				}
+			} else if dstKind == reflect.Interface && dstElement.Kind() == reflect.Interface {
+				if err = deepMerge(dstElement, srcElement, visited, depth + 1, overwrite); err != nil {
+					return
+				}
+			} else if srcKind == reflect.Map {
+				if err = deepMap(dstElement, srcElement, visited, depth + 1, overwrite); err != nil {
 					return
 				}
 			} else {
-				if srcKind == reflect.Map {
-					if err = deepMap(dstElement, srcElement, visited, depth+1, overwrite); err != nil {
-						return
-					}
-					if dstKind == reflect.Interface {
-						if err = deepMerge(dstElement, srcElement, visited, depth + 1, overwrite); err != nil {
-							return
-						}
-					}
-				} else {
-					return fmt.Errorf("type mismatch on %s field: found %v, expected %v", fieldName, srcKind, dstKind)
-				}
+				return fmt.Errorf("type mismatch on %s field: found %v, expected %v", fieldName, srcKind, dstKind)
 			}
 		}
 	}
@@ -137,7 +134,7 @@ func MapWithOverwrite(dst, src interface{}) error {
 func _map(dst, src interface{}, overwrite bool) error {
 	var (
 		vDst, vSrc reflect.Value
-		err        error
+		err error
 	)
 	if vDst, vSrc, err = resolveValues(dst, src); err != nil {
 		return err

--- a/map.go
+++ b/map.go
@@ -39,7 +39,9 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, over
 		typ := dst.Type()
 		for p := seen; p != nil; p = p.next {
 			if p.ptr == addr && p.typ == typ {
-				return nil
+				if typ.Kind() != reflect.Interface {
+					return nil
+				}
 			}
 		}
 		// Remember, remember...
@@ -96,6 +98,11 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, over
 				if srcKind == reflect.Map {
 					if err = deepMap(dstElement, srcElement, visited, depth+1, overwrite); err != nil {
 						return
+					}
+					if dstKind == reflect.Interface {
+						if err = deepMerge(dstElement, srcElement, visited, depth + 1, overwrite); err != nil {
+							return
+						}
 					}
 				} else {
 					return fmt.Errorf("type mismatch on %s field: found %v, expected %v", fieldName, srcKind, dstKind)

--- a/map.go
+++ b/map.go
@@ -39,9 +39,7 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, over
 		typ := dst.Type()
 		for p := seen; p != nil; p = p.next {
 			if p.ptr == addr && p.typ == typ {
-				if typ.Kind() != reflect.Interface {
 					return nil
-				}
 			}
 		}
 		// Remember, remember...

--- a/merge.go
+++ b/merge.go
@@ -40,6 +40,10 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, ov
 			}
 		}
 	case reflect.Map:
+		if len(src.MapKeys()) == 0 {
+			dst.Set(reflect.MakeMap(dst.Type()))
+			return
+		}
 		for _, key := range src.MapKeys() {
 			srcElement := src.MapIndex(key)
 			if !srcElement.IsValid() {

--- a/merge.go
+++ b/merge.go
@@ -26,7 +26,9 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, ov
 		typ := dst.Type()
 		for p := seen; p != nil; p = p.next {
 			if p.ptr == addr && p.typ == typ {
-				return nil
+				if typ.Kind() != reflect.Interface {
+					return nil
+				}
 			}
 		}
 		// Remember, remember...
@@ -81,6 +83,14 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, ov
 	case reflect.Ptr:
 		fallthrough
 	case reflect.Interface:
+		if src.Kind() != reflect.Interface {
+			if dst.IsNil() || overwrite {
+				if dst.CanSet() && (overwrite || isEmptyValue(dst)) {
+					dst.Set(src)
+				}
+			}
+			break
+		}
 		if src.IsNil() {
 			break
 		} else if dst.IsNil() || overwrite {

--- a/merge.go
+++ b/merge.go
@@ -40,7 +40,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, ov
 			}
 		}
 	case reflect.Map:
-		if len(src.MapKeys()) == 0 && len(dst.MapKeys()) == 0 {
+		if len(src.MapKeys()) == 0 && !src.IsNil() && len(dst.MapKeys()) == 0 {
 			dst.Set(reflect.MakeMap(dst.Type()))
 			return
 		}

--- a/merge.go
+++ b/merge.go
@@ -40,7 +40,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, ov
 			}
 		}
 	case reflect.Map:
-		if len(src.MapKeys()) == 0 {
+		if len(src.MapKeys()) == 0 && len(dst.MapKeys()) == 0 {
 			dst.Set(reflect.MakeMap(dst.Type()))
 			return
 		}

--- a/merge.go
+++ b/merge.go
@@ -26,9 +26,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, ov
 		typ := dst.Type()
 		for p := seen; p != nil; p = p.next {
 			if p.ptr == addr && p.typ == typ {
-				if typ.Kind() != reflect.Interface {
 					return nil
-				}
 			}
 		}
 		// Remember, remember...
@@ -88,6 +86,16 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, ov
 				if dst.CanSet() && (overwrite || isEmptyValue(dst)) {
 					dst.Set(src)
 				}
+			} else if src.Kind() == reflect.Ptr {
+				if err = deepMerge(dst.Elem(), src.Elem(), visited, depth + 1, overwrite); err != nil {
+					return
+				}
+			} else if dst.Elem().Type() == src.Type() {
+				if err = deepMerge(dst.Elem(), src, visited, depth + 1, overwrite); err != nil {
+					return
+				}
+			} else {
+				return ErrDifferentArgumentsTypes
 			}
 			break
 		}

--- a/mergo_test.go
+++ b/mergo_test.go
@@ -264,6 +264,22 @@ func TestEmptyMaps(t *testing.T) {
 	}
 }
 
+func TestEmptyToNotEmptyMaps(t *testing.T) {
+	a := mapTest{map[int]int{
+		1 : 2,
+		3 : 4,
+	}}
+	b := mapTest{
+		map[int]int{},
+	}
+	if err := Merge(&a, b); err != nil {
+		t.Fail()
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.FailNow()
+	}
+}
+
 func TestMapsWithOverwrite(t *testing.T) {
 	m := map[string]simpleTest{
 		"a": {},   // overwritten by 16

--- a/mergo_test.go
+++ b/mergo_test.go
@@ -23,6 +23,14 @@ type complexTest struct {
 	ID string
 }
 
+type mapTest struct {
+	M map[int]int
+}
+
+type ifcTest struct {
+	I interface{}
+}
+
 type moreComplextText struct {
 	Ct complexTest
 	St simpleTest
@@ -243,6 +251,19 @@ func TestSliceStruct(t *testing.T) {
 	}
 }
 
+func TestEmptyMaps(t *testing.T) {
+	a := mapTest{}
+	b := mapTest{
+		map[int]int{},
+	}
+	if err := Merge(&a, b); err != nil {
+		t.Fail()
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.FailNow()
+	}
+}
+
 func TestMapsWithOverwrite(t *testing.T) {
 	m := map[string]simpleTest{
 		"a": {},   // overwritten by 16
@@ -389,6 +410,45 @@ func TestSimpleMap(t *testing.T) {
 	}
 	if a.Value != 42 {
 		t.Fatalf("b not merged in properly: a.Value(%d) != b.Value(%v)", a.Value, b["value"])
+	}
+}
+
+func TestIfcMap(t *testing.T) {
+	a := ifcTest{}
+	b := ifcTest{42}
+	if err := Map(&a, b); err != nil {
+		t.FailNow()
+	}
+	if a.I != 42 {
+		t.Fatalf("b not merged in properly: a.I(%d) != b.I(%d)", a.I, b.I)
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.FailNow()
+	}
+}
+
+func TestIfcMapNoOverwrite(t *testing.T) {
+	a := ifcTest{13}
+	b := ifcTest{42}
+	if err := Map(&a, b); err != nil {
+		t.FailNow()
+	}
+	if a.I != 13 {
+		t.Fatalf("a not left alone: a.I(%d) == b.I(%d)", a.I, b.I)
+	}
+}
+
+func TestIfcMapWithOverwrite(t *testing.T) {
+	a := ifcTest{13}
+	b := ifcTest{42}
+	if err := MapWithOverwrite(&a, b); err != nil {
+		t.FailNow()
+	}
+	if a.I != 42 {
+		t.Fatalf("b not merged in properly: a.I(%d) != b.I(%d)", a.I, b.I)
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.FailNow()
 	}
 }
 

--- a/mergo_test.go
+++ b/mergo_test.go
@@ -264,6 +264,17 @@ func TestEmptyMaps(t *testing.T) {
 	}
 }
 
+func TestEmptyToEmptyMaps(t *testing.T) {
+	a := mapTest{}
+	b := mapTest{}
+	if err := Merge(&a, b); err != nil {
+		t.Fail()
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.FailNow()
+	}
+}
+
 func TestEmptyToNotEmptyMaps(t *testing.T) {
 	a := mapTest{map[int]int{
 		1 : 2,


### PR DESCRIPTION
- empty structs and interfaces (interfaced maps) are merged, while empty maps are not, this should fix it
- allow mapping of interface values to go through