### PR TITLE
fix missing return in Transformer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ func (t timeTransfomer) Transformer(typ reflect.Type) func(dst, src reflect.Valu
 					dst.Set(src)
 				}
 			}
+			return nil
 		}
 	}
 	return nil


### PR DESCRIPTION
Hi,
The Transformers example is missing a return at the end of the function, this PR fixes the docs.
Regards, Thomas