### PR TITLE
Protect even more merge with transformer from nil/invalid values

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -54,14 +54,8 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 		visited[h] = &visit{addr, typ, seen}
 	}
 
-	if config.transformers != nil {
+	if config.transformers != nil && !isEmptyValue(dst) {
 		if fn := config.transformers.Transformer(dst.Type()); fn != nil {
-			if isEmptyValue(dst) {
-				if dst.CanSet() && !isEmptyValue(src) {
-					dst.Set(src)
-				}
-				return
-			}
 			err = fn(dst, src)
 			return
 		}


### PR DESCRIPTION
Follow-up on 1d277f002eb9497b3b159eaf52bcc6e658571a95, simplify the code
path and handle one more panic (`reflect.Value.Type` will panic in case
of `Invalid`, where `reflect.Value.Kind()` won't).

So, if dst is empty (i.e. `Invalid`), we bypass transformer (as we don't
need to)

cc @imdario — somehow I didn't catch this one yesterday 🤦‍♂️ 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>