### PR TITLE
Fix a case of merging a map of pointer with nil values

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -86,7 +86,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 			}
 			dstElement := dst.MapIndex(key)
 			switch srcElement.Kind() {
-			case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Interface, reflect.Slice:
+			case reflect.Chan, reflect.Func, reflect.Map, reflect.Interface, reflect.Slice:
 				if srcElement.IsNil() {
 					continue
 				}
@@ -122,7 +122,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 				continue
 			}
 
-			if !isEmptyValue(srcElement) && (overwrite || (!dstElement.IsValid() || isEmptyValue(dst))) {
+			if srcElement.IsValid() && (overwrite || (!dstElement.IsValid() || isEmptyValue(dst))) {
 				if dst.IsNil() {
 					dst.Set(reflect.MakeMap(dst.Type()))
 				}

--- a/mergo_test.go
+++ b/mergo_test.go
@@ -405,6 +405,30 @@ func TestMaps(t *testing.T) {
 	}
 }
 
+func TestMapsWithNilPointer(t *testing.T) {
+	m := map[string]*simpleTest{
+		"a": nil,
+		"b": nil,
+	}
+	n := map[string]*simpleTest{
+		"b": nil,
+		"c": nil,
+	}
+	expect := map[string]*simpleTest{
+		"a": nil,
+		"b": nil,
+		"c": nil,
+	}
+
+	if err := Merge(&m, n, WithOverride); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	if !reflect.DeepEqual(m, expect) {
+		t.Fatalf("Test failed:\ngot   :\n%#v\n\nwant :\n%#v\n\n", m, expect)
+	}
+}
+
 func TestYAMLMaps(t *testing.T) {
 	thing := loadYAML("testdata/thing.yml")
 	license := loadYAML("testdata/license.yml")
@@ -666,10 +690,10 @@ type structWithUnexportedProperty struct {
 
 func TestUnexportedProperty(t *testing.T) {
 	a := structWithMap{map[string]structWithUnexportedProperty{
-		"key": structWithUnexportedProperty{"hello"},
+		"key": {"hello"},
 	}}
 	b := structWithMap{map[string]structWithUnexportedProperty{
-		"key": structWithUnexportedProperty{"hi"},
+		"key": {"hi"},
 	}}
 	defer func() {
 		if r := recover(); r != nil {


### PR DESCRIPTION
Before this change, merging maps with nil pointer values would not give
the expected merged map.

The test fails without this fix in `merge.go`.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>