### PR TITLE
Override slices if WithOverride is specified

### DIFF
--- a/issue64_test.go
+++ b/issue64_test.go
@@ -1,0 +1,38 @@
+package mergo
+
+import (
+	"testing"
+)
+
+type Student struct {
+	Name  string
+	Books []string
+}
+
+var testData = []struct {
+	S1            Student
+	S2            Student
+	ExpectedSlice []string
+}{
+	{Student{"Jack", []string{"a", "B"}}, Student{"Tom", []string{"1"}}, []string{"a", "B"}},
+	{Student{"Jack", []string{"a", "B"}}, Student{"Tom", []string{}}, []string{"a", "B"}},
+	{Student{"Jack", []string{}}, Student{"Tom", []string{"1"}}, []string{"1"}},
+	{Student{"Jack", []string{}}, Student{"Tom", []string{}}, []string{}},
+}
+
+func TestIssue64MergeSliceWithOverride(t *testing.T) {
+	for _, data := range testData {
+		err := Merge(&data.S2, data.S1, WithOverride)
+		if err != nil {
+			t.Errorf("Error while merging %s", err)
+		}
+		if len(data.S2.Books) != len(data.ExpectedSlice) {
+			t.Fatalf("Got %d elements in slice, but expected %d", len(data.S2.Books), len(data.ExpectedSlice))
+		}
+		for i, val := range data.S2.Books {
+			if val != data.ExpectedSlice[i] {
+				t.Fatalf("Expected %s, but got %s while merging slice with override", data.ExpectedSlice[i], val)
+			}
+		}
+	}
+}

--- a/merge.go
+++ b/merge.go
@@ -130,7 +130,11 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 			}
 		}
 	case reflect.Slice:
-		dst.Set(reflect.AppendSlice(dst, src))
+		if !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) {
+			dst.Set(src)
+		} else {
+			dst.Set(reflect.AppendSlice(dst, src))
+		}
 	case reflect.Ptr:
 		fallthrough
 	case reflect.Interface:


### PR DESCRIPTION
This PR is for issue https://github.com/imdario/mergo/issues/64. The expectation is that merging slices while specify WithOverride will override the slices instead of appending. Default behavior of appending makes sense without the WithOverride flag. Let me know if this approach and thinking makes sense. It's been super useful for a project I'm working on with config overrides, so thanks for the project! 