### PR TITLE
Add an option to append slice

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -26,6 +26,7 @@ func hasExportedField(dst reflect.Value) (exported bool) {
 
 type Config struct {
 	Overwrite    bool
+	AppendSlice  bool
 	Transformers Transformers
 }
 
@@ -134,7 +135,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 		if !dst.CanSet() {
 			break
 		}
-		if !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) {
+		if !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
 			dst.Set(src)
 		} else {
 			dst.Set(reflect.AppendSlice(dst, src))
@@ -203,6 +204,11 @@ func WithTransformers(transformers Transformers) func(*Config) {
 // WithOverride will make merge override non-empty dst attributes with non-empty src attributes values.
 func WithOverride(config *Config) {
 	config.Overwrite = true
+}
+
+// WithAppendSlice will make merge append slices instead of overwriting it
+func WithAppendSlice(config *Config) {
+	config.AppendSlice = true
 }
 
 func merge(dst, src interface{}, opts ...func(*Config)) error {

--- a/merge_appendslice_test.go
+++ b/merge_appendslice_test.go
@@ -1,0 +1,33 @@
+package mergo
+
+import (
+	"testing"
+)
+
+var testDataS = []struct {
+	S1            Student
+	S2            Student
+	ExpectedSlice []string
+}{
+	{Student{"Jack", []string{"a", "B"}}, Student{"Tom", []string{"1"}}, []string{"1", "a", "B"}},
+	{Student{"Jack", []string{"a", "B"}}, Student{"Tom", []string{}}, []string{"a", "B"}},
+	{Student{"Jack", []string{}}, Student{"Tom", []string{"1"}}, []string{"1"}},
+	{Student{"Jack", []string{}}, Student{"Tom", []string{}}, []string{}},
+}
+
+func TestMergeSliceWithOverrideWithAppendSlice(t *testing.T) {
+	for _, data := range testDataS {
+		err := Merge(&data.S2, data.S1, WithOverride, WithAppendSlice)
+		if err != nil {
+			t.Errorf("Error while merging %s", err)
+		}
+		if len(data.S2.Books) != len(data.ExpectedSlice) {
+			t.Fatalf("Got %d elements in slice, but expected %d", len(data.S2.Books), len(data.ExpectedSlice))
+		}
+		for i, val := range data.S2.Books {
+			if val != data.ExpectedSlice[i] {
+				t.Fatalf("Expected %s, but got %s while merging slice with override", data.ExpectedSlice[i], val)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Commit e6c5cef change the behavior of how mergo handles slice when
`WithOverride` is used. This adds an option to preserve the previous
behavior.

We used that behavior in `docker/cli`, updating breaks some tests, so, adding a way to restore the behavior without making it default though :wink: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>