### PR TITLE
Fix merge of sub map stored in a map[]interface{}

### DIFF
--- a/issueXX_test.go
+++ b/issueXX_test.go
@@ -1,0 +1,42 @@
+package mergo
+
+import (
+	"testing"
+)
+
+func TestMapInterfaceWithMultipleLayer(t *testing.T) {
+	m1 := map[string]interface{}{
+		"k1": map[string]interface{}{
+			"k1.1": "v1",
+		},
+	}
+
+	m2 := map[string]interface{}{
+		"k1": map[string]interface{}{
+			"k1.1": "v2",
+			"k1.2": "v3",
+		},
+	}
+
+	if err := Map(&m1, m2, WithOverride); err != nil {
+		t.Fatalf("Error merging: %v", err)
+	}
+
+	// Check overwrite of sub map works
+	expected := "v2"
+	actual := m1["k1"].(map[string]interface{})["k1.1"].(string)
+	if actual != expected {
+		t.Fatalf("Expected %v but got %v",
+			expected,
+			actual)
+	}
+
+	// Check new key is merged
+	expected = "v3"
+	actual = m1["k1"].(map[string]interface{})["k1.2"].(string)
+	if actual != expected {
+		t.Fatalf("Expected %v but got %v",
+			expected,
+			actual)
+	}
+}

--- a/merge.go
+++ b/merge.go
@@ -103,7 +103,15 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 				case reflect.Ptr:
 					fallthrough
 				case reflect.Map:
-					if err = deepMerge(dstElement, srcElement, visited, depth+1, config); err != nil {
+					srcMapElm := srcElement
+					dstMapElm := dstElement
+					if srcMapElm.CanInterface() {
+						srcMapElm = reflect.ValueOf(srcMapElm.Interface())
+						if dstMapElm.IsValid() {
+							dstMapElm = reflect.ValueOf(dstMapElm.Interface())
+						}
+					}
+					if err = deepMerge(dstMapElm, srcMapElm, visited, depth+1, config); err != nil {
 						return
 					}
 				case reflect.Slice:
@@ -124,7 +132,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 				continue
 			}
 
-			if srcElement.IsValid() && (overwrite || (!dstElement.IsValid() || isEmptyValue(dst))) {
+			if srcElement.IsValid() && (overwrite || (!dstElement.IsValid() || isEmptyValue(dstElement))) {
 				if dst.IsNil() {
 					dst.Set(reflect.MakeMap(dst.Type()))
 				}


### PR DESCRIPTION
See https://github.com/micro/go-config/issues/18

This PR should fix map[]interface{} containing maps