### PR TITLE
Don't append slice if not asked to

### DIFF
--- a/issue66_test.go
+++ b/issue66_test.go
@@ -20,6 +20,25 @@ func TestPrivateSlice(t *testing.T) {
 	if err := Merge(&p1, p2); err != nil {
 		t.Fatalf("Error during the merge: %v", err)
 	}
+	if len(p1.PublicStrings) != 3 {
+		t.Error("5 elements should be in 'PublicStrings' field")
+	}
+	if len(p1.privateStrings) != 2 {
+		t.Error("2 elements should be in 'privateStrings' field")
+	}
+}
+
+func TestPrivateSliceWithAppendSlice(t *testing.T) {
+	p1 := PrivateSliceTest66{
+		PublicStrings:  []string{"one", "two", "three"},
+		privateStrings: []string{"four", "five"},
+	}
+	p2 := PrivateSliceTest66{
+		PublicStrings: []string{"six", "seven"},
+	}
+	if err := Merge(&p1, p2, WithAppendSlice); err != nil {
+		t.Fatalf("Error during the merge: %v", err)
+	}
 	if len(p1.PublicStrings) != 5 {
 		t.Error("5 elements should be in 'PublicStrings' field")
 	}

--- a/merge.go
+++ b/merge.go
@@ -124,7 +124,11 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 						dstSlice = reflect.ValueOf(dstElement.Interface())
 					}
 
-					dstSlice = reflect.AppendSlice(dstSlice, srcSlice)
+					if !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
+						dstSlice = srcSlice
+					} else if config.AppendSlice {
+						dstSlice = reflect.AppendSlice(dstSlice, srcSlice)
+					}
 					dst.SetMapIndex(key, dstSlice)
 				}
 			}
@@ -145,7 +149,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 		}
 		if !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
 			dst.Set(src)
-		} else {
+		} else if config.AppendSlice {
 			dst.Set(reflect.AppendSlice(dst, src))
 		}
 	case reflect.Ptr:


### PR DESCRIPTION
Fix the case when we don't ask for slice to be appended but are
because of `src` and `dst` values.

cc @imdario seems like this is the cause of the build failure [here](https://github.com/moby/moby/pull/37239/files)

```
09:18:39 --- FAIL: TestLoadDaemonConfigWithNetwork (0.00s)
09:18:39 	daemon_unix_test.go:46: assertion failed: 127.0.0.1 (string) != ?00000000000000000000ffff7f00000100000000000000000000ffff00000000 (string)
```

I'm not a huge fan of that change as it's probably going to break current usage : a `slice` in a `map` is always appending, with this change it will only be appended if it is asked to

```
~/s/g/i/mergo{slice-merge-fix} λ go test ./...
ok      github.com/imdario/mergo        0.002s
```

Signed-off-by: Vincent Demeester <vincent@sbr.pm>