### PR TITLE
Fixes #84

### DIFF
--- a/issue84_test.go
+++ b/issue84_test.go
@@ -1,0 +1,82 @@
+package mergo
+
+import (
+	"testing"
+)
+
+type DstStructIssue84 struct {
+	A int
+	B int
+	C int
+}
+
+type DstNestedStructIssue84 struct {
+	A struct {
+		A int
+		B int
+		C int
+	}
+	B int
+	C int
+}
+
+func TestIssue84MergeMapWithNilValueToStructWithOverride(t *testing.T) {
+	p1 := DstStructIssue84{
+		A: 0, B: 1, C: 2,
+	}
+	p2 := map[string]interface{}{
+		"A": 3, "B": 4, "C": 0,
+	}
+	if err := Map(&p1, p2, WithOverride); err != nil {
+		t.Fatalf("Error during the merge: %v", err)
+	}
+	if p1.C != 0 {
+		t.Error("C field should become '0'")
+	}
+}
+
+func TestIssue84MergeMapWithoutKeyExistsToStructWithOverride(t *testing.T) {
+	p1 := DstStructIssue84{
+		A: 0, B: 1, C: 2,
+	}
+	p2 := map[string]interface{}{
+		"A": 3, "B": 4,
+	}
+	if err := Map(&p1, p2, WithOverride); err != nil {
+		t.Fatalf("Error during the merge: %v", err)
+	}
+	if p1.C != 2 {
+		t.Error("C field should be '2'")
+	}
+}
+
+func TestIssue84MergeNestedMapWithNilValueToStructWithOverride(t *testing.T) {
+	p1 := DstNestedStructIssue84{
+		A: struct {
+			A int
+			B int
+			C int
+		}{A: 1, B: 2, C: 0},
+		B: 0,
+		C: 2,
+	}
+	p2 := map[string]interface{}{
+		"A": map[string]interface{}{
+			"A": 0, "B": 0, "C": 5,
+		}, "B": 4, "C": 0,
+	}
+	if err := Map(&p1, p2, WithOverride); err != nil {
+		t.Fatalf("Error during the merge: %v", err)
+	}
+	if p1.B != 4 {
+		t.Error("A.C field should become '4'")
+	}
+
+	if p1.A.C != 5 {
+		t.Error("A.C field should become '5'")
+	}
+
+	if p1.A.B != 0 || p1.A.A != 0 {
+		t.Error("A.A and A.B field should become '0'")
+	}
+}

--- a/map.go
+++ b/map.go
@@ -72,6 +72,7 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, conf
 	case reflect.Struct:
 		srcMap := src.Interface().(map[string]interface{})
 		for key := range srcMap {
+			config.overwriteWithEmptyValue = true
 			srcValue := srcMap[key]
 			fieldName := changeInitialCase(key, unicode.ToUpper)
 			dstElement := dst.FieldByName(fieldName)


### PR DESCRIPTION
In order to make **deepMerge** func know that it the **src** value was specially indicated in the source map(key exists) we need to pass some flag to it. And set this flag in case  **deepMerge** while going through the source map keys.
 
One variant is to Implement unexported **overwriteWithEmptyValue** in the **Config**. So there is no need to extend  **deepMerge**.

I have also wrote some basic tests