### PR TITLE
Appending slice can cause Mergo to panic…

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -9,6 +9,7 @@
 package mergo
 
 import (
+	"fmt"
 	"reflect"
 )
 
@@ -127,6 +128,9 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 					if !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
 						dstSlice = srcSlice
 					} else if config.AppendSlice {
+						if srcSlice.Type() != dstSlice.Type() {
+							return fmt.Errorf("cannot append two slice with different type (%s, %s)", srcSlice.Type(), dstSlice.Type())
+						}
 						dstSlice = reflect.AppendSlice(dstSlice, srcSlice)
 					}
 					dst.SetMapIndex(key, dstSlice)
@@ -150,6 +154,9 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 		if !isEmptyValue(src) && (overwrite || isEmptyValue(dst)) && !config.AppendSlice {
 			dst.Set(src)
 		} else if config.AppendSlice {
+			if src.Type() != dst.Type() {
+				return fmt.Errorf("cannot append two slice with different type (%s, %s)", src.Type(), dst.Type())
+			}
 			dst.Set(reflect.AppendSlice(dst, src))
 		}
 	case reflect.Ptr:

--- a/mergo_test.go
+++ b/mergo_test.go
@@ -731,3 +731,25 @@ func TestBooleanPointer(t *testing.T) {
 		t.Fatalf("dst.C should be true")
 	}
 }
+
+func TestMergeMapWithInnerSliceOfDifferentType(t *testing.T) {
+	src := map[string]interface{}{
+		"foo": []string{"a", "b"},
+	}
+	dst := map[string]interface{}{
+		"foo": []int{1, 2},
+	}
+
+	if err := Merge(&src, &dst, WithOverride, WithAppendSlice); err == nil {
+		t.Fatal("expected an error, got nothing")
+	}
+}
+
+func TestMergeSliceDifferentType(t *testing.T) {
+	src := []string{"a", "b"}
+	dst := []int{1, 2}
+
+	if err := Merge(&src, &dst, WithOverride, WithAppendSlice); err == nil {
+		t.Fatal("expected an error, got nothing")
+	}
+}


### PR DESCRIPTION
… mainly if the slice are not of the same type. Fixes this by
returning an error if the two slices are of different type instead of panicking.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>