### PR TITLE
Adding support for flags within structs

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -72,6 +72,9 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 	case reflect.Struct:
 		if hasExportedField(dst) {
 			for i, n := 0, dst.NumField(); i < n; i++ {
+				if dst.Type().Field(i).Tag.Get("mergo") == "savedst" {
+					continue
+				}
 				if err = deepMerge(dst.Field(i), src.Field(i), visited, depth+1, config); err != nil {
 					return
 				}

--- a/prXX_test.go
+++ b/prXX_test.go
@@ -1,0 +1,39 @@
+package mergo
+
+import (
+	"testing"
+)
+
+type flagStruct struct {
+	Save 	bool  `mergo:"savedst"`
+}
+
+type invalidFlagStruct struct {
+	Save 	bool 
+}
+
+
+func Test_MergoWithoutFlags(t *testing.T) {
+	src := invalidFlagStruct{false}
+	dst := invalidFlagStruct{true}
+	if err := Merge(&dst, src); err != nil {
+		t.FailNow()
+	}
+
+	if dst.Save == false {
+		t.Fatalf("dst.Save was saved which is wrong")
+	}
+}
+
+
+func Test_MergoWithFlags(t *testing.T) {
+	src := flagStruct{false}
+	dst := flagStruct{true}
+	if err := Merge(&dst, src); err != nil {
+		t.FailNow()
+	}
+
+	if dst.Save == false {
+		t.Fatalf("dst.Save was not saved but overriden")
+	}
+}


### PR DESCRIPTION
If you want to merge a struct with a struct, and save the information in dst you can now just set the flag: mergo:"savedst" and it will be saved but the rest of the struct will be replaced.