### PR TITLE
WIP: Change slice merge order

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -160,7 +160,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 			if src.Type() != dst.Type() {
 				return fmt.Errorf("cannot append two slice with different type (%s, %s)", src.Type(), dst.Type())
 			}
-			dst.Set(reflect.AppendSlice(dst, src))
+			dst.Set(reflect.AppendSlice(src, dst))
 		}
 	case reflect.Ptr:
 		fallthrough

--- a/merge_appendslice_test.go
+++ b/merge_appendslice_test.go
@@ -9,7 +9,7 @@ var testDataS = []struct {
 	S2            Student
 	ExpectedSlice []string
 }{
-	{Student{"Jack", []string{"a", "B"}}, Student{"Tom", []string{"1"}}, []string{"1", "a", "B"}},
+	{Student{"Jack", []string{"a", "B"}}, Student{"Tom", []string{"1"}}, []string{"a", "B", "1"}},
 	{Student{"Jack", []string{"a", "B"}}, Student{"Tom", []string{}}, []string{"a", "B"}},
 	{Student{"Jack", []string{}}, Student{"Tom", []string{"1"}}, []string{"1"}},
 	{Student{"Jack", []string{}}, Student{"Tom", []string{}}, []string{}},


### PR DESCRIPTION
This PR fixes issue #101. 
I hope it is a change you agree with, let me know if further actions are required, like making it configurable in which order the slices to be merged or if this is a breaking backwards compatibility issue.
In my opinion the order we merge the elements in the slice matters and it should follow the merge order of the elements.