### PR TITLE
Fix the ci for pull-requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ install:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
 script:
+  - go test -race -v ./...
+after_script:
   - $HOME/gopath/bin/goveralls -service=travis-ci -repotoken $COVERALLS_TOKEN


### PR DESCRIPTION
- Run tests as script (with race condition)
- Put `goverwalls` as `after_script` so a failure to upload the
  coverage won't affect the status of the build

cc @imdario 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>