### PR TITLE
Update merge.go

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -31,7 +31,7 @@ type Config struct {
 	TypeCheck                    bool
 	Transformers                 Transformers
 	overwriteWithEmptyValue      bool
-	overwriteSliceWithEmptyValue bool
+	OverwriteSliceWithEmptyValue bool
 }
 
 type Transformers interface {
@@ -44,9 +44,8 @@ type Transformers interface {
 func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, config *Config) (err error) {
 	overwrite := config.Overwrite
 	typeCheck := config.TypeCheck
-	overwriteWithEmptySrc := config.overwriteWithEmptyValue
+	overwriteWithEmptySrc := config.OverwriteWithEmptyValue
 	overwriteSliceWithEmptySrc := config.overwriteSliceWithEmptyValue
-	config.overwriteWithEmptyValue = false
 
 	if !src.IsValid() {
 		return
@@ -244,6 +243,11 @@ func WithTransformers(transformers Transformers) func(*Config) {
 // WithOverride will make merge override non-empty dst attributes with non-empty src attributes values.
 func WithOverride(config *Config) {
 	config.Overwrite = true
+}
+
+// WithOverwriteWithEmptyValue will make merge override non empty dst attributes with empty src attributes values.
+func WithOverwriteWithEmptyValue(config *Config) {
+	config.OverwriteWithEmptyValue = true
 }
 
 // WithOverride will make merge override empty dst slice with empty src slice.


### PR DESCRIPTION
Make "OverwriteWithEmptyValue" in config struct to be set by any method, so that the merge can be customizable. In cases, where request toggles a boolean value and the the request message can change a "true" value to false we can pass the flag to merge accordingly, which is not possible otherwise.