### PR TITLE
Make "OverwriteWithEmptyValue" in config struct to be set by any method.

### DIFF
--- a/map.go
+++ b/map.go
@@ -72,7 +72,7 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, conf
 	case reflect.Struct:
 		srcMap := src.Interface().(map[string]interface{})
 		for key := range srcMap {
-			config.overwriteWithEmptyValue = true
+			config.OverwriteWithEmptyValue = true
 			srcValue := srcMap[key]
 			fieldName := changeInitialCase(key, unicode.ToUpper)
 			dstElement := dst.FieldByName(fieldName)

--- a/map.go
+++ b/map.go
@@ -72,7 +72,7 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, conf
 	case reflect.Struct:
 		srcMap := src.Interface().(map[string]interface{})
 		for key := range srcMap {
-			config.OverwriteWithEmptyValue = true
+			config.overwriteWithEmptyValue = true
 			srcValue := srcMap[key]
 			fieldName := changeInitialCase(key, unicode.ToUpper)
 			dstElement := dst.FieldByName(fieldName)

--- a/merge.go
+++ b/merge.go
@@ -30,7 +30,7 @@ type Config struct {
 	AppendSlice                  bool
 	TypeCheck                    bool
 	Transformers                 Transformers
-	OverwriteWithEmptyValue      bool
+	overwriteWithEmptyValue      bool
 	overwriteSliceWithEmptyValue bool
 }
 

--- a/merge.go
+++ b/merge.go
@@ -247,7 +247,7 @@ func WithOverride(config *Config) {
 
 // WithOverwriteWithEmptyValue will make merge override non empty dst attributes with empty src attributes values.
 func WithOverwriteWithEmptyValue(config *Config) {
-	config.OverwriteWithEmptyValue = true
+	config.overwriteWithEmptyValue = true
 }
 
 // WithOverride will make merge override empty dst slice with empty src slice.

--- a/merge.go
+++ b/merge.go
@@ -44,7 +44,7 @@ type Transformers interface {
 func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, config *Config) (err error) {
 	overwrite := config.Overwrite
 	typeCheck := config.TypeCheck
-	overwriteWithEmptySrc := config.OverwriteWithEmptyValue
+	overwriteWithEmptySrc := config.overwriteWithEmptyValue
 	overwriteSliceWithEmptySrc := config.overwriteSliceWithEmptyValue
 
 	if !src.IsValid() {

--- a/merge.go
+++ b/merge.go
@@ -30,7 +30,7 @@ type Config struct {
 	AppendSlice                  bool
 	TypeCheck                    bool
 	Transformers                 Transformers
-	overwriteWithEmptyValue      bool
+	OverwriteWithEmptyValue      bool
 	overwriteSliceWithEmptyValue bool
 }
 
@@ -44,9 +44,8 @@ type Transformers interface {
 func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, config *Config) (err error) {
 	overwrite := config.Overwrite
 	typeCheck := config.TypeCheck
-	overwriteWithEmptySrc := config.overwriteWithEmptyValue
+	overwriteWithEmptySrc := config.OverwriteWithEmptyValue
 	overwriteSliceWithEmptySrc := config.overwriteSliceWithEmptyValue
-	config.overwriteWithEmptyValue = false
 
 	if !src.IsValid() {
 		return
@@ -244,6 +243,11 @@ func WithTransformers(transformers Transformers) func(*Config) {
 // WithOverride will make merge override non-empty dst attributes with non-empty src attributes values.
 func WithOverride(config *Config) {
 	config.Overwrite = true
+}
+
+// WithOverwriteWithEmptyValue will make merge override non empty dst attributes with empty src attributes values.
+func WithOverwriteWithEmptyValue(config *Config) {
+	config.OverwriteWithEmptyValue = true
 }
 
 // WithOverride will make merge override empty dst slice with empty src slice.


### PR DESCRIPTION
The caller can decide whether to overwrite with empty values or not if we allow this flag "overwriteWithEmptyValue" to be set by the caller method.
This make the merge more customizable, especially in cases, where request toggles a boolean value and the the request message can change a "true" value to false we can pass the flag to merge accordingly, which is not possible otherwise.