### PR TITLE
merge: test dst is a pointer

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -266,6 +266,9 @@ func WithTypeCheck(config *Config) {
 }
 
 func merge(dst, src interface{}, opts ...func(*Config)) error {
+	if dst != nil && reflect.ValueOf(dst).Kind() != reflect.Ptr {
+		return ErrNonPointerAgument
+	}
 	var (
 		vDst, vSrc reflect.Value
 		err        error

--- a/merge_test.go
+++ b/merge_test.go
@@ -48,3 +48,12 @@ func TestMergeWithTransformerNilStruct(t *testing.T) {
 		t.Fatalf("b not merged in properly: a.Bar shouldn't be nil")
 	}
 }
+
+func TestMergeNonPointer(t *testing.T) {
+	dst := bar{i: 1}
+	src := bar{i: 2, s: map[string]string{"a": "1"}}
+	want := ErrNonPointerAgument
+	if got := merge(dst, src); got != want {
+		t.Fatalf("want: %s, got: %s", want, got)
+	}
+}

--- a/mergo.go
+++ b/mergo.go
@@ -20,6 +20,7 @@ var (
 	ErrNotSupported                = errors.New("only structs and maps are supported")
 	ErrExpectedMapAsDestination    = errors.New("dst was expected to be a map")
 	ErrExpectedStructAsDestination = errors.New("dst was expected to be a struct")
+	ErrNonPointerAgument           = errors.New("dst must be a pointer")
 )
 
 // During deepMerge, must keep track of checks that are


### PR DESCRIPTION
Maybe returning an error instead of panicking when `func merge(dst, src interface{}, opts ...func(*Config)) error` receives dst != pointer would be interesting?

In my case, it took me a good 30min to figure out that `Merge` expected a pointer as a first argument.

### Reproducing the current isssue:
```
package main

import (
        "fmt"

        "github.com/imdario/mergo"
)

type A struct {
        B int
        C string
}

func main() {
        src := A{1, "s"}
        dst := A{B: 1}
        if err := mergo.Merge(dst, src); err != nil {
                fmt.Println(err)
        }
}
```
will panic:
```
panic: reflect: call of reflect.Value.Elem on struct Value

goroutine 1 [running]:
reflect.Value.Elem(0x4b4220, 0xc00000c080, 0x99, 0xc00007cd18, 0x203000, 0x0)
        /usr/lib/go/src/reflect/value.go:830 +0x1c3
github.com/imdario/mergo.resolveValues(0x4b4220, 0xc00000c080, 0x4b4220, 0xc00000c0a0, 0x3, 0x8, 0x8, 0x10, 0x203000, 0x58, ...)
        /tmp/Go/pkg/mod/github.com/imdario/mergo@v0.3.8/mergo.go:66 +0xb7
github.com/imdario/mergo.merge(0x4b4220, 0xc00000c080, 0x4b4220, 0xc00000c0a0, 0x0, 0x0, 0x0, 0xc00007cf20, 0x437e5a)
        /tmp/Go/pkg/mod/github.com/imdario/mergo@v0.3.8/merge.go:276 +0xc3
github.com/imdario/mergo.Merge(...)
        /tmp/Go/pkg/mod/github.com/imdario/mergo@v0.3.8/merge.go:227
main.main()
        /tmp/Lab/go/pointer-test/main.go:17 +0xec
exit status 2
```

### With this PR
returns:
```
dst must be a pointer
```