### PR TITLE
merge struct fields of type interface{} that contain data with the same concrete type

### DIFF
--- a/merge_interface_concrete_test.go
+++ b/merge_interface_concrete_test.go
@@ -40,3 +40,37 @@ func TestMergeInterfaceWithDifferentConcreteTypes(t *testing.T) {
 		t.Errorf("Handler not merged in properly: got %q header value %q, want %q", "Test", got, want)
 	}
 }
+
+func TestMergeInterfaceWithSameConcreteTypes(t *testing.T) {
+	type testStruct struct {
+		Name string
+		Value string
+	}
+	type interfaceStruct struct {
+		Field interface{}
+	}
+	dst := interfaceStruct{
+		Field: testStruct{
+			Value: "keepMe",
+		},
+	}
+
+	src := interfaceStruct{
+		Field: testStruct{
+			Name: t.Name(),
+		},
+	}
+
+	if err := Merge(&dst, src); err != nil {
+		t.Errorf("Error while merging %s", err)
+	}
+
+	dstData := dst.Field.(testStruct)
+	srcData := src.Field.(testStruct)
+	if dstData.Name != srcData.Name {
+		t.Errorf("dst name was not updated: got %s, want %s", dstData.Name, srcData.Name)
+	}
+	if dstData.Value != "keepMe" {
+		t.Errorf("dst value was not preserved: got %s, want %s", dstData.Value, "keepMe")
+	}
+}


### PR DESCRIPTION
If a struct has two fields that are of interface type but contain data that is the same type, we should be able to deepMerge into that. This patch adds test coverage and support for this use case.

What this does, really, is

1. move the dst.Kind() != ptr && isAssignable check to the end (because it took precedence over the "else deepMerge" case)
2. only call deepMerge if the underlying Elem() values are the same kind
3. modify the deepMerge call so that dst is populated (otherwise, if the value being passed to deepMerge has "CanSet() == false", which it does, then the result is lost).