### PR TITLE
fix typo in error name

### DIFF
--- a/map.go
+++ b/map.go
@@ -142,7 +142,7 @@ func MapWithOverwrite(dst, src interface{}, opts ...func(*Config)) error {
 
 func _map(dst, src interface{}, opts ...func(*Config)) error {
 	if dst != nil && reflect.ValueOf(dst).Kind() != reflect.Ptr {
-		return ErrNonPointerAgument
+		return ErrNonPointerArgument
 	}
 	var (
 		vDst, vSrc reflect.Value

--- a/merge.go
+++ b/merge.go
@@ -339,7 +339,7 @@ func WithSliceDeepCopy(config *Config) {
 
 func merge(dst, src interface{}, opts ...func(*Config)) error {
 	if dst != nil && reflect.ValueOf(dst).Kind() != reflect.Ptr {
-		return ErrNonPointerAgument
+		return ErrNonPointerArgument
 	}
 	var (
 		vDst, vSrc reflect.Value

--- a/merge_test.go
+++ b/merge_test.go
@@ -64,7 +64,7 @@ func TestMergeNonPointer(t *testing.T) {
 			"a": "1",
 		},
 	}
-	want := mergo.ErrNonPointerAgument
+	want := mergo.ErrNonPointerArgument
 
 	if got := mergo.Merge(dst, src); got != want {
 		t.Errorf("want: %s, got: %s", want, got)
@@ -81,7 +81,7 @@ func TestMapNonPointer(t *testing.T) {
 			},
 		},
 	}
-	want := mergo.ErrNonPointerAgument
+	want := mergo.ErrNonPointerArgument
 	if got := mergo.Merge(dst, src); got != want {
 		t.Errorf("want: %s, got: %s", want, got)
 	}

--- a/mergo.go
+++ b/mergo.go
@@ -20,7 +20,7 @@ var (
 	ErrNotSupported                = errors.New("only structs and maps are supported")
 	ErrExpectedMapAsDestination    = errors.New("dst was expected to be a map")
 	ErrExpectedStructAsDestination = errors.New("dst was expected to be a struct")
-	ErrNonPointerAgument           = errors.New("dst must be a pointer")
+	ErrNonPointerArgument          = errors.New("dst must be a pointer")
 )
 
 // During deepMerge, must keep track of checks that are


### PR DESCRIPTION
Hi,

I came across a typo while looking at how merge was implemented.