### PR TITLE
Fix panic that occurs when a struct has a blank field

### DIFF
--- a/issue174_test.go
+++ b/issue174_test.go
@@ -1,0 +1,21 @@
+package mergo_test
+
+import (
+	"testing"
+
+	"github.com/imdario/mergo"
+)
+
+type structWithBlankField struct {
+	_ struct{}
+	A struct{}
+}
+
+func TestIssue174(t *testing.T) {
+	dst := structWithBlankField{}
+	src := structWithBlankField{}
+
+	if err := mergo.Merge(&dst, src, mergo.WithOverride); err != nil {
+		t.Error(err)
+	}
+}

--- a/merge.go
+++ b/merge.go
@@ -95,7 +95,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 				}
 			}
 		} else {
-			if (isReflectNil(dst) || overwrite) && (!isEmptyValue(src) || overwriteWithEmptySrc) {
+			if dst.CanSet() && (isReflectNil(dst) || overwrite) && (!isEmptyValue(src) || overwriteWithEmptySrc) {
 				dst.Set(src)
 			}
 		}


### PR DESCRIPTION
This PR fixes https://github.com/imdario/mergo/issues/174.