### PR TITLE
use src map if dst is nil and can't be set

### DIFF
--- a/issue90_test.go
+++ b/issue90_test.go
@@ -1,0 +1,43 @@
+package mergo_test
+
+import (
+	"github.com/imdario/mergo"
+	"reflect"
+	"testing"
+)
+
+type structWithStringMap struct {
+	Data map[string]string
+}
+
+
+func TestIssue90(t *testing.T) {
+    dst := map[string]structWithStringMap{
+    	"struct": {
+    		Data: nil,
+		},
+	}
+	src := map[string]structWithStringMap{
+		"struct": {
+			Data: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+	expected := map[string]structWithStringMap{
+		"struct": {
+			Data: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	err := mergo.Merge(&dst, src, mergo.WithOverride)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	if !reflect.DeepEqual(dst, expected) {
+		t.Errorf("expected: %#v\ngot: %#v", expected, dst)
+	}
+}

--- a/merge.go
+++ b/merge.go
@@ -101,7 +101,12 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 		}
 	case reflect.Map:
 		if dst.IsNil() && !src.IsNil() {
-			dst.Set(reflect.MakeMap(dst.Type()))
+			if dst.CanSet() {
+				dst.Set(reflect.MakeMap(dst.Type()))
+			} else {
+				dst = src
+				return
+			}
 		}
 
 		if src.Kind() != reflect.Map {


### PR DESCRIPTION
As a struct field of type `map` is processed, and was not initialized as non-nil, don't try to set with a fresh new map and just adopt src value.
As I'm not sure about the potential side-effects, I've kept the original logic for cases where dst can be set. 

fix #90 

related: 
- https://github.com/docker/compose-cli/issues/1261
- https://github.com/docker/cli/issues/2916
- https://github.com/docker/cli/issues/1981