### PR TITLE
Adding StructBot to Mergo in the wild section

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ If Mergo is useful to you, consider buying me a coffee, a beer, or making a mont
 - [jnuthong/item_search](https://github.com/jnuthong/item_search)
 - [bukalapak/snowboard](https://github.com/bukalapak/snowboard)
 - [containerssh/containerssh](https://github.com/containerssh/containerssh)
+- [tjpnz/structbot](https://github.com/tjpnz/structbot)
 
 ## Install
 


### PR DESCRIPTION
I've recently released StructBot aimed at simplifying struct initialization for test cases. The patch functionality contained in the library leverages Mergo under the hood so I thought this would be a worthy addition.