### PR TITLE
use isReflectNil instead of isEmptyValue to gate Transformers

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -79,7 +79,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 		visited[h] = &visit{addr, typ, seen}
 	}
 
-	if config.Transformers != nil && !isEmptyValue(dst) {
+	if config.Transformers != nil && !isReflectNil(dst) {
 		if fn := config.Transformers.Transformer(dst.Type()); fn != nil {
 			err = fn(dst, src)
 			return


### PR DESCRIPTION
Hi!

While using this great library, I came across a few issues mostly related to how `mergo` handles zero-values (https://github.com/imdario/mergo/issues/166). Based on the comments from various contributors, I decided to write a custom Transformer to handle my use-case as I wished, but then I realized it wasn't possible, as transformers are executed only if the `dst` is not an "empty" value (https://github.com/imdario/mergo/blob/master/merge.go#L82-L87). Therefore, we cannot apply any transformer to values like `false`, `0` etc.

What I'm proposing with this PR is to use [isReflectNil](https://github.com/imdario/mergo/blob/master/merge.go#L370-L380) instead of [isEmptyValue](https://github.com/imdario/mergo/blob/master/mergo.go#L37-L60) to gate transformers execution.

Following is an example of the usage I'm envisioning:

```
package mergo_test

import (
	"reflect"
	"testing"

	"github.com/GGabriele/mergo"
)

type asd struct {
	A *bool
}

type boolTransformer struct{}

func Bool(v bool) *bool { return &v }

func (t boolTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
	if typ == reflect.TypeOf(Bool(false)) {
		return func(dst, src reflect.Value) error {
			if dst.CanSet() {
				if src.IsNil() {
					src.Set(dst)
				}
			}
			return nil
		}
	}
	return nil
}

func TestBoolPointers(t *testing.T) {
	// base false, augment true
	base := asd{
		A: Bool(false),
	}
	augment := asd{
		A: Bool(true),
	}
	if err := mergo.Merge(&base, augment, mergo.WithTransformers(boolTransformer{})); err != nil {
		t.Error(err)
	}
	if *base.A != false {
		t.Errorf("1. base.A should be false")
	}

	// base true, augment false
	base = asd{
		A: Bool(true),
	}
	augment = asd{
		A: Bool(false),
	}
	if err := mergo.Merge(&base, augment, mergo.WithTransformers(boolTransformer{})); err != nil {
		t.Error(err)
	}
	if *base.A != true {
		t.Errorf("2. base.A should be true")
	}

	// base empty, augment false
	base = asd{}
	augment = asd{
		A: Bool(false),
	}
	if err := mergo.Merge(&base, augment, mergo.WithTransformers(boolTransformer{})); err != nil {
		t.Error(err)
	}
	if *base.A != false {
		t.Errorf("3. base.A should be false")
	}

	// base empty, augment true
	base = asd{}
	augment = asd{
		A: Bool(true),
	}
	if err := mergo.Merge(&base, augment, mergo.WithTransformers(boolTransformer{})); err != nil {
		t.Error(err)
	}
	if *base.A != true {
		t.Errorf("4. base.A should be true")
	}
}

```

Let me know what you think!