### PR TITLE
fix: gate transformers on valid non-nil destinations

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -79,7 +79,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 		visited[h] = &visit{addr, typ, seen}
 	}
 
-	if config.Transformers != nil && !isEmptyValue(dst) {
+	if config.Transformers != nil && !isReflectNil(dst) && dst.IsValid() {
 		if fn := config.Transformers.Transformer(dst.Type()); fn != nil {
 			err = fn(dst, src)
 			return

--- a/pr211_2_test.go
+++ b/pr211_2_test.go
@@ -1,0 +1,25 @@
+package mergo
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+type transformer struct {
+}
+
+func (s *transformer) Transformer(t reflect.Type) func(dst, src reflect.Value) error {
+	return nil
+}
+
+func Test_deepMergeTransformerInvalidDestination(t *testing.T) {
+	foo := time.Time{}
+	src := reflect.ValueOf(foo)
+	deepMerge(reflect.Value{}, src, make(map[uintptr]*visit), 0, &Config{
+		Transformers: &transformer{},
+	})
+	// this test is intentionally not asserting on anything, it's sole
+	// purpose to verify deepMerge doesn't panic when a transformer is
+	// passed and the destination is invalid.
+}

--- a/pr211_test.go
+++ b/pr211_test.go
@@ -1,0 +1,36 @@
+package mergo_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/imdario/mergo"
+)
+
+func TestMergeWithTransformerZeroValue(t *testing.T) {
+	// This test specifically tests that a transformer can be used to
+	// prevent overwriting a zero value (in this case a bool). This would fail prior to #211
+	type fooWithBoolPtr struct {
+		b *bool
+	}
+	var Bool = func(b bool) *bool { return &b }
+	a := fooWithBoolPtr{b: Bool(false)}
+	b := fooWithBoolPtr{b: Bool(true)}
+
+	if err := mergo.Merge(&a, &b, mergo.WithTransformers(&transformer{
+		m: map[reflect.Type]func(dst, src reflect.Value) error{
+			reflect.TypeOf(Bool(false)): func(dst, src reflect.Value) error {
+				if dst.CanSet() && dst.IsNil() {
+					dst.Set(src)
+				}
+				return nil
+			},
+		},
+	})); err != nil {
+		t.Error(err)
+	}
+
+	if *a.b != false {
+		t.Errorf("b not merged in properly: a.b(%v) != expected(%v)", a.b, false)
+	}
+}


### PR DESCRIPTION
This builds on #203 which attempted to provide a more flexible gating to
running transformers. However upon testing #203 in my own environment, I
ran into the first panic listed below.

There are a variety of errors that can happen when trying to run
reflection on zero values:

2 just from my testing of this PR
```
        panic: reflect: call of reflect.Value.Type on zero Value

        panic: reflect: call of reflect.Value.FieldByName on zero Value
```
The panic specifically calls out zero values, but it's actual a more
specific set of values which is covered by `reflect.IsValid`.

I attempted to replace the check with `reflect.IsZero`, which ends up
being too restrictive and breaks existing tests. I also attempted to
solely use `reflect.IsZero` which is not restrictive enough and cause
the later panic above in the tests. Thus I arrived on the combination in
this PR which seems to strike the "right" balance.