### PR TITLE
Fix unaligned structs

### DIFF
--- a/issue123_test.go
+++ b/issue123_test.go
@@ -23,20 +23,20 @@ func TestIssue123(t *testing.T) {
 		t.Fatal(err)
 	}
 	testCases := []struct {
-		key      string
 		expected interface{}
+		key      string
 	}{
 		{
+			nil,
 			"col1",
-			nil,
 		},
 		{
-			"col2",
 			4,
+			"col2",
 		},
 		{
-			"col3",
 			nil,
+			"col3",
 		},
 	}
 	for _, tC := range testCases {

--- a/issue136_test.go
+++ b/issue136_test.go
@@ -12,8 +12,8 @@ type embeddedTestA struct {
 }
 
 type embeddedTestB struct {
-	embeddedTestA
 	Address string
+	embeddedTestA
 }
 
 func TestMergeEmbedded(t *testing.T) {

--- a/issue143_test.go
+++ b/issue143_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestIssue143(t *testing.T) {
 	testCases := []struct {
-		options  []func(*mergo.Config)
 		expected func(map[string]interface{}) error
+		options  []func(*mergo.Config)
 	}{
 		{
 			options: []func(*mergo.Config){mergo.WithOverride},

--- a/issue89_test.go
+++ b/issue89_test.go
@@ -33,20 +33,20 @@ func TestIssue89MergeWithEmptyValue(t *testing.T) {
 		t.Error(err)
 	}
 	testCases := []struct {
-		key      string
 		expected interface{}
+		key      string
 	}{
 		{
-			"A",
 			3,
+			"A",
 		},
 		{
-			"B",
 			"",
+			"B",
 		},
 		{
-			"C",
 			false,
+			"C",
 		},
 	}
 	for _, tC := range testCases {

--- a/issue90_test.go
+++ b/issue90_test.go
@@ -10,11 +10,10 @@ type structWithStringMap struct {
 	Data map[string]string
 }
 
-
 func TestIssue90(t *testing.T) {
-    dst := map[string]structWithStringMap{
-    	"struct": {
-    		Data: nil,
+	dst := map[string]structWithStringMap{
+		"struct": {
+			Data: nil,
 		},
 	}
 	src := map[string]structWithStringMap{

--- a/map.go
+++ b/map.go
@@ -44,7 +44,7 @@ func deepMap(dst, src reflect.Value, visited map[uintptr]*visit, depth int, conf
 			}
 		}
 		// Remember, remember...
-		visited[h] = &visit{addr, typ, seen}
+		visited[h] = &visit{typ, seen, addr}
 	}
 	zeroValue := reflect.Value{}
 	switch dst.Kind() {

--- a/merge.go
+++ b/merge.go
@@ -38,10 +38,10 @@ func isExportedComponent(field *reflect.StructField) bool {
 }
 
 type Config struct {
+	Transformers                 Transformers
 	Overwrite                    bool
 	AppendSlice                  bool
 	TypeCheck                    bool
-	Transformers                 Transformers
 	overwriteWithEmptyValue      bool
 	overwriteSliceWithEmptyValue bool
 	sliceDeepCopy                bool
@@ -76,7 +76,7 @@ func deepMerge(dst, src reflect.Value, visited map[uintptr]*visit, depth int, co
 			}
 		}
 		// Remember, remember...
-		visited[h] = &visit{addr, typ, seen}
+		visited[h] = &visit{typ, seen, addr}
 	}
 
 	if config.Transformers != nil && !isReflectNil(dst) && dst.IsValid() {

--- a/merge_test.go
+++ b/merge_test.go
@@ -19,13 +19,13 @@ func (s *transformer) Transformer(t reflect.Type) func(dst, src reflect.Value) e
 }
 
 type foo struct {
-	s   string
 	Bar *bar
+	s   string
 }
 
 type bar struct {
-	i int
 	s map[string]string
+	i int
 }
 
 func TestMergeWithTransformerNilStruct(t *testing.T) {

--- a/mergo.go
+++ b/mergo.go
@@ -28,9 +28,9 @@ var (
 // checks in progress are true when it reencounters them.
 // Visited are stored in a map indexed by 17 * a1 + a2;
 type visit struct {
-	ptr  uintptr
 	typ  reflect.Type
 	next *visit
+	ptr  uintptr
 }
 
 // From src/pkg/encoding/json/encode.go.

--- a/mergo_test.go
+++ b/mergo_test.go
@@ -21,9 +21,9 @@ type simpleTest struct {
 }
 
 type complexTest struct {
+	ID string
 	St simpleTest
 	sz int
-	ID string
 }
 
 type mapTest struct {
@@ -50,8 +50,8 @@ type sliceTest struct {
 
 func TestKb(t *testing.T) {
 	type testStruct struct {
-		Name     string
 		KeyValue map[string]interface{}
+		Name     string
 	}
 
 	akv := make(map[string]interface{})
@@ -116,7 +116,7 @@ func TestSimpleStruct(t *testing.T) {
 func TestComplexStruct(t *testing.T) {
 	a := complexTest{}
 	a.ID = "athing"
-	b := complexTest{simpleTest{42}, 1, "bthing"}
+	b := complexTest{"bthing", simpleTest{42}, 1}
 	if err := mergo.Merge(&a, b); err != nil {
 		t.FailNow()
 	}
@@ -132,10 +132,10 @@ func TestComplexStruct(t *testing.T) {
 }
 
 func TestComplexStructWithOverwrite(t *testing.T) {
-	a := complexTest{simpleTest{1}, 1, "do-not-overwrite-with-empty-value"}
-	b := complexTest{simpleTest{42}, 2, ""}
+	a := complexTest{"do-not-overwrite-with-empty-value", simpleTest{1}, 1}
+	b := complexTest{"", simpleTest{42}, 2}
 
-	expect := complexTest{simpleTest{42}, 1, "do-not-overwrite-with-empty-value"}
+	expect := complexTest{"do-not-overwrite-with-empty-value", simpleTest{42}, 1}
 	if err := mergo.MergeWithOverwrite(&a, b); err != nil {
 		t.FailNow()
 	}
@@ -417,22 +417,22 @@ func TestMergeUsingStructAndMap(t *testing.T) {
 		Msg2 string
 	}
 	type params struct {
-		Name  string
 		Multi *multiPtr
 		Final *final
+		Name  string
 	}
 	type config struct {
+		Params *params
 		Foo    string
 		Bar    string
-		Params *params
 	}
 
 	cases := []struct {
-		name      string
-		overwrite bool
 		changes   *config
 		target    *config
 		output    *config
+		name      string
+		overwrite bool
 	}{
 		{
 			name:      "Should overwrite values in target for non-nil values in source",
@@ -721,13 +721,13 @@ func TestIfcMapWithOverwrite(t *testing.T) {
 }
 
 type pointerMapTest struct {
+	B      *simpleTest
 	A      int
 	hidden int
-	B      *simpleTest
 }
 
 func TestBackAndForth(t *testing.T) {
-	pt := pointerMapTest{42, 1, &simpleTest{66}}
+	pt := pointerMapTest{&simpleTest{66}, 42, 1}
 	m := make(map[string]interface{})
 	if err := mergo.Map(&m, pt); err != nil {
 		t.FailNow()
@@ -763,8 +763,8 @@ func TestBackAndForth(t *testing.T) {
 
 func TestEmbeddedPointerUnpacking(t *testing.T) {
 	tests := []struct{ input pointerMapTest }{
-		{pointerMapTest{42, 1, nil}},
-		{pointerMapTest{42, 1, &simpleTest{66}}},
+		{pointerMapTest{nil, 42, 1}},
+		{pointerMapTest{&simpleTest{66}, 42, 1}},
 	}
 	newValue := 77
 	m := map[string]interface{}{
@@ -900,18 +900,18 @@ func TestBooleanPointer(t *testing.T) {
 func TestMergeMapWithInnerSliceOfDifferentType(t *testing.T) {
 	testCases := []struct {
 		name    string
-		options []func(*mergo.Config)
 		err     string
+		options []func(*mergo.Config)
 	}{
 		{
 			"With override and append slice",
-			[]func(*mergo.Config){mergo.WithOverride, mergo.WithAppendSlice},
 			"cannot append two slices with different type",
+			[]func(*mergo.Config){mergo.WithOverride, mergo.WithAppendSlice},
 		},
 		{
 			"With override and type check",
-			[]func(*mergo.Config){mergo.WithOverride, mergo.WithTypeCheck},
 			"cannot override two slices with different type",
+			[]func(*mergo.Config){mergo.WithOverride, mergo.WithTypeCheck},
 		},
 	}
 	for _, tc := range testCases {

--- a/v039_bugs_test.go
+++ b/v039_bugs_test.go
@@ -53,8 +53,8 @@ func TestV039Issue152(t *testing.T) {
 }
 
 type issue146Foo struct {
-	A string
 	B map[string]issue146Bar
+	A string
 }
 
 type issue146Bar struct {


### PR DESCRIPTION
Using `fieldalignment` to reduce some bytes.

```bash
go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest
go vet -vettool=$(which fieldalignment) ./...
fieldalignment -fix ./...
```

Output on first run:

```
# github.com/imdario/mergo
./merge.go:40:13: struct of size 32 could be 24
./mergo.go:30:12: struct with 32 pointer bytes could be 24
# github.com/imdario/mergo_test
./issue123_test.go:25:17: struct with 32 pointer bytes could be 24
./issue136_test.go:14:20: struct with 32 pointer bytes could be 24
./issue143_test.go:11:17: struct with 32 pointer bytes could be 16
./issue89_test.go:35:17: struct with 32 pointer bytes could be 24
./merge_test.go:21:10: struct with 24 pointer bytes could be 16
./merge_test.go:26:10: struct with 16 pointer bytes could be 8
./mergo_test.go:23:18: struct with 24 pointer bytes could be 8
./mergo_test.go:52:18: struct with 24 pointer bytes could be 16
./mergo_test.go:419:14: struct with 32 pointer bytes could be 24
./mergo_test.go:424:14: struct with 40 pointer bytes could be 32
./mergo_test.go:430:13: struct with 48 pointer bytes could be 32
./mergo_test.go:723:21: struct with 24 pointer bytes could be 8
./mergo_test.go:901:17: struct with 48 pointer bytes could be 40
./v039_bugs_test.go:55:18: struct with 24 pointer bytes could be 16
```